### PR TITLE
Fix error when copying Nodes to Kernel

### DIFF
--- a/svm.go
+++ b/svm.go
@@ -196,6 +196,7 @@ func NewKernel(l int, x [][]SVMNode, param *SVMParameter) *Kernel {
 	m.gamma = param.Gamma
 	m.coef0 = param.Coef0
 	// x.clone
+	m.x = make([][]SVMNode, len(x))
 	copy(m.x, x)
 
 	if m.kernelType == RBF {


### PR DESCRIPTION
in golang, copy() only copies until the smallest slice is full. This way, nothing was copied.
